### PR TITLE
Add unit declarator to module and class declarations

### DIFF
--- a/lib/DateTime/Format.pm6
+++ b/lib/DateTime/Format.pm6
@@ -1,6 +1,6 @@
 use v6;
 
-module DateTime::Format;
+unit module DateTime::Format;
 
 ## Default list of Month names.
 ## Add more by loading DateTime::Format::Lang::* modules.

--- a/lib/DateTime/Format/Factory.pm6
+++ b/lib/DateTime/Format/Factory.pm6
@@ -1,7 +1,7 @@
 use DateTime::Format;
 
 ## A Parent Class for Format objects.
-class DateTime::Format::Factory does Callable;
+unit class DateTime::Format::Factory does Callable;
 
 #use DateTime::Format;
 

--- a/lib/DateTime/Format/Lang/BG.pm6
+++ b/lib/DateTime/Format/Lang/BG.pm6
@@ -1,4 +1,4 @@
-module DateTime::Format::Lang::BG;
+unit module DateTime::Format::Lang::BG;
 
 use DateTime::Format :ALL;
 

--- a/lib/DateTime/Format/Lang/DE.pm6
+++ b/lib/DateTime/Format/Lang/DE.pm6
@@ -1,4 +1,4 @@
-module DateTime::Format::Lang::DE;
+unit module DateTime::Format::Lang::DE;
 
 use DateTime::Format :ALL;
 

--- a/lib/DateTime/Format/Lang/FR.pm6
+++ b/lib/DateTime/Format/Lang/FR.pm6
@@ -1,4 +1,4 @@
-module DateTime::Format::Lang::FR;
+unit module DateTime::Format::Lang::FR;
 
 use DateTime::Format :ALL;
 

--- a/lib/DateTime/Format/RFC2822.pm6
+++ b/lib/DateTime/Format/RFC2822.pm6
@@ -1,6 +1,6 @@
 use DateTime::Format::Factory;
 
-class DateTime::Format::RFC2822 is DateTime::Format::Factory;
+unit class DateTime::Format::RFC2822 is DateTime::Format::Factory;
 
 ## RFC2822
 ##


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.