### PR TITLE
Fix the Travis configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Makefile
 blib
+.precomp

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,4 @@ perl6:
 install:
   - rakudobrew build-panda
   - panda --notests installdeps .
-script:
-  - perl6 -MPanda::Builder -e 'Panda::Builder.build($*CWD)'
-  - PERL6LIB=$PWD/blib/lib prove -e perl6 -vr t/
 sudo: false


### PR DESCRIPTION
The travis build was failing because the way the build was being done.

The travis language setting now does the right thing anyway so the explicit build and test is unnececessary.
